### PR TITLE
Treat sections as LaTeX in detex.

### DIFF
--- a/chrisper
+++ b/chrisper
@@ -167,6 +167,7 @@ class Paper(object):
             text = re.sub(r'\\-', '', text)
             # Run it through detex
             p = subprocess.Popen(["detex",
+                                  "-l",
                                   "-n",
                                   "-e",
                                   ','.join(ignored_environments)],


### PR DESCRIPTION
Without this addition, ignored sections (e.g., verbatim) in latex files without the `\begin{document}` text are included in the detex output.
